### PR TITLE
[SWM-353] 스트릭 응답 데이터 추가

### DIFF
--- a/src/main/java/com/swmStrong/demo/domain/streak/controller/StreakController.java
+++ b/src/main/java/com/swmStrong/demo/domain/streak/controller/StreakController.java
@@ -5,6 +5,7 @@ import com.swmStrong.demo.common.response.ApiResponse;
 import com.swmStrong.demo.common.response.CustomResponseEntity;
 import com.swmStrong.demo.config.security.principal.SecurityPrincipal;
 import com.swmStrong.demo.domain.streak.dto.DailyActivityResponseDto;
+import com.swmStrong.demo.domain.streak.dto.StreakDashboardDto;
 import com.swmStrong.demo.domain.streak.dto.StreakResponseDto;
 import com.swmStrong.demo.domain.streak.service.StreakService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -76,7 +77,7 @@ public class StreakController {
                     "<p> days-before 에 값을 넣지 않을 시의 기본값은 100일이다. </p>"
     )
     @GetMapping("/matrix")
-    public ResponseEntity<ApiResponse<List<DailyActivityResponseDto>>> getActivitiesByPast100Days(
+    public ResponseEntity<ApiResponse<StreakDashboardDto>> getDailyActivitiesBetweenDateAndDaysBefore(
             @AuthenticationPrincipal SecurityPrincipal principal,
             @RequestParam
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)

--- a/src/main/java/com/swmStrong/demo/domain/streak/dto/StreakDashboardDto.java
+++ b/src/main/java/com/swmStrong/demo/domain/streak/dto/StreakDashboardDto.java
@@ -1,0 +1,12 @@
+package com.swmStrong.demo.domain.streak.dto;
+
+import java.util.List;
+
+public record StreakDashboardDto(
+        StreakResponseDto streakSummary,
+        List<DailyActivityResponseDto> dailyActivities
+) {
+    public static StreakDashboardDto from(StreakResponseDto streakResponseDto, List<DailyActivityResponseDto> dailyActivities) {
+        return new StreakDashboardDto(streakResponseDto, dailyActivities);
+    }
+}

--- a/src/main/java/com/swmStrong/demo/domain/streak/service/StreakService.java
+++ b/src/main/java/com/swmStrong/demo/domain/streak/service/StreakService.java
@@ -1,6 +1,7 @@
 package com.swmStrong.demo.domain.streak.service;
 
 import com.swmStrong.demo.domain.streak.dto.DailyActivityResponseDto;
+import com.swmStrong.demo.domain.streak.dto.StreakDashboardDto;
 import com.swmStrong.demo.domain.streak.dto.StreakResponseDto;
 
 import java.time.LocalDate;
@@ -9,5 +10,5 @@ import java.util.List;
 public interface StreakService {
     StreakResponseDto getStreakCount(String userId);
     List<DailyActivityResponseDto> getDailyActivitiesByMonth(String userId, LocalDate date);
-    List<DailyActivityResponseDto> getDailyActivitiesBetweenDateAndDaysBefore(String userId, LocalDate date, Long daysBefore);
+    StreakDashboardDto getDailyActivitiesBetweenDateAndDaysBefore(String userId, LocalDate date, Long daysBefore);
 }

--- a/src/main/java/com/swmStrong/demo/domain/streak/service/StreakServiceImpl.java
+++ b/src/main/java/com/swmStrong/demo/domain/streak/service/StreakServiceImpl.java
@@ -3,6 +3,7 @@ package com.swmStrong.demo.domain.streak.service;
 import com.swmStrong.demo.common.exception.ApiException;
 import com.swmStrong.demo.common.exception.code.ErrorCode;
 import com.swmStrong.demo.domain.streak.dto.DailyActivityResponseDto;
+import com.swmStrong.demo.domain.streak.dto.StreakDashboardDto;
 import com.swmStrong.demo.domain.streak.dto.StreakResponseDto;
 import com.swmStrong.demo.domain.streak.entity.DailyActivity;
 import com.swmStrong.demo.domain.streak.entity.Streak;
@@ -62,11 +63,17 @@ public class StreakServiceImpl implements StreakService {
     }
 
     @Override
-    public List<DailyActivityResponseDto> getDailyActivitiesBetweenDateAndDaysBefore(String userId, LocalDate date, Long daysBefore) {
+    public StreakDashboardDto getDailyActivitiesBetweenDateAndDaysBefore(String userId, LocalDate date, Long daysBefore) {
         List<DailyActivity> dailyActivityList = dailyActivityRepository.findByUserIdAndActivityDateBetween(
                 userId, date.minusDays(daysBefore), date);
-        return dailyActivityList.stream()
+
+        List<DailyActivityResponseDto> dailyActivityResponseDto = dailyActivityList.stream()
                 .map(DailyActivityResponseDto::of)
                 .toList();
+
+        StreakResponseDto streak = getStreakCount(userId);
+
+        return StreakDashboardDto.from(streak, dailyActivityResponseDto);
+
     }
 }


### PR DESCRIPTION
# ⭐ 작업 분류
- [ ] 테스트
- [x] 신규 기능
- [ ] 코드 수정
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 디자인 수정
- [ ] 치명적 버그 수정
- [ ] 기타 작업 (주석, 스타일 등)

---

## ✅ Check List
- [ ] 테스트가 전부 통과되었나요?
- [x] 빌드는 성공했나요?
- [x] 모든 commit이 push 되었나요?
- [x] merge할 branch를 확인했나요?
- [x] Assignee를 지정했나요?
- [x] Label을 지정했나요?

---

## 📝 작업 개요
> 어떤 작업을 했는지 간단하게 작성해주세요.
- 스트릭 응답 데이터 추가 
---

## 🔍 작업 상세 내용
> 왜 그런 로직을 작성했는지 자세히 알려주세요.  
> 기존 코드에서 무엇이 수정되었는지,  
> 어떤 생각으로 컴포넌트를 분리하였는지 등을 설명해주세요.

- DailyActivity 를 반환하는 API가 항상 Streak과 같은 블럭에 위치 하고, 이를 통해 네트워크 리소스를 줄일 수 있다고 판단해 이를 합쳐 하나의 엔드포인트에서 처리할 수 있도록 수정했습니다. 

---

## ⏰ 리뷰 시간 예상
> ex) 약 10분 정도 예상됩니다.

---

## 💬 기타 메시지
> 다음 스크럼에 할 일, 리뷰어에게 부탁할 말, 특이사항 등을 적어주세요.

---

## 📸 Test Screenshot / 시연 이미지
> 변경 사항을 참고하기 쉽게 스크린샷을 첨부해주세요.  
> 시연을 위한 gif도 좋습니다.

---

## 🔗 관련 이슈
> 예: Close #1, Fix #42